### PR TITLE
feat(react): add scrollbar utility class

### DIFF
--- a/js/react/lib/styles.css
+++ b/js/react/lib/styles.css
@@ -83,7 +83,7 @@
 
   --color-light: #fafafa;
   --color-dark: #2e2e2e;
-  --color-gray: #D9D9D9;
+  --color-gray: #d9d9d9;
 
   /* Fonts */
   --text-xxs: 10px;
@@ -301,5 +301,32 @@
     letter-spacing: 0.32%;
 
     @apply desktop:text-[40px];
+  }
+}
+
+@layer utilities {
+  @supports not selector(::-webkit-scrollbar) {
+    .scrollbar {
+      scrollbar-color: var(--color-neutral-300) var(--color-neutral-100);
+
+      @variant dark {
+        scrollbar-color: var(--color-neutral-900) var(--color-neutral-600);
+      }
+    }
+  }
+
+  .scrollbar::-webkit-scrollbar {
+    @apply w-4;
+  }
+
+  .scrollbar::-webkit-scrollbar-track {
+    @apply rounded-full bg-neutral-100 dark:bg-neutral-900;
+  }
+
+  .scrollbar::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-neutral-300 transition dark:bg-neutral-600;
+  }
+  .scrollbar::-webkit-scrollbar-thumb:hover {
+    @apply opacity-90;
   }
 }

--- a/js/react/showcase/App.tsx
+++ b/js/react/showcase/App.tsx
@@ -258,6 +258,11 @@ export function App() {
           },
         }}
       />
+      <ShowComponent title="Scroll bar ">
+        <div className="scrollbar mx-auto h-48 w-full overflow-auto">
+          <div className="mx-auto flex h-96 w-20 items-center">Container</div>
+        </div>
+      </ShowComponent>
     </div>
   );
 }


### PR DESCRIPTION
### Related Issue
Related to #25 

### Summary
.scrollbar class to change scrollbar styles

### Details
The styles for Firefox are different since some features, like border-radius, are not supported. However, the colors are set as shown in the design. If full cross-browser support is required, let me know so I can dedicate more time and implement it for Firefox as well :)

### Type-safe (pnpm check:tsc)
Integrated into showcase/App.tsx

### Screenshots

> Firefox

<img src="https://github.com/user-attachments/assets/d16402d3-99c5-4194-8ef2-6d3c476680d6" width="300"/>
<img src="https://github.com/user-attachments/assets/fdf3c423-4103-4ef5-a477-e6098daa44fa" width="300"/>

&nbsp;
> Safari

<img src="https://github.com/user-attachments/assets/1a65911d-0289-4da8-b08c-1e3ef1a3b878" width="300"/> 
<img src="https://github.com/user-attachments/assets/5a7d4204-a3d7-4b6f-9e54-c15c5b48dfc9" width="300"/>

&nbsp;
> Chrome

<img src="https://github.com/user-attachments/assets/c432a7e5-519e-4cc9-ad58-1dc92a7cdd03" width="300"/>
<img src="https://github.com/user-attachments/assets/082bd402-0e9a-4559-86ec-1a698c390211" width="300"/>


